### PR TITLE
Extract code into `oscoin_client` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -719,7 +719,17 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oscoin_client 0.1.0",
  "oscoin_ledger 0.1.0",
+ "web3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "oscoin_client"
+version = "0.1.0"
+dependencies = [
+ "ethabi 8.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "web3 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,6 @@ env_logger = "0.6.2"
 hex = "0.3.1"
 clap = "2.31"
 oscoin_ledger = { path = "./ledger", features = ["std"] }
+oscoin_client = { path = "./client" }
 
 [workspace]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "oscoin_client"
+description = "Client library for talking to the oscoin ledger running on a full node."
+version = "0.1.0"
+authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
+edition = "2018"
+
+[dependencies]
+web3 = "0.8.0"
+ethabi = "8.0.0"
+rustc-hex = "2.0.1"

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -1,0 +1,110 @@
+///! Client library for talking
+///
+/// # Getting Started
+///
+/// ```
+/// let client = Client::new_from_file();
+/// client.ping().wait().unwrap();
+/// ```
+use std::error;
+use std::fmt;
+use std::str::FromStr;
+
+use web3::contract::{Contract, Options};
+use web3::transports::http::Http;
+use web3::transports::EventLoopHandle;
+use web3::types::Address;
+use web3::Transport;
+
+/// URL pointing to a parity ethereum node running on localhost.
+///
+/// This is the URL used by the client. It is currently not possible to change it.
+const LOCALHOST_NODE_URL: &str = "http://localhost:8545";
+
+const CONTRACT_ABI_JSON: &[u8] = include_bytes!("../../target/json/Ledger.json");
+
+/// File Path to load and store the ledger contract address to. Is `./.oscoin_ledger_address`.
+pub const CONTRACT_ADDRESS_FILE: &str = "./.oscoin_ledger_address";
+
+/// Error returned when reading the contract address from a file fails.
+#[derive(Debug)]
+pub enum ReadContractAddressError {
+    HexError(rustc_hex::FromHexError),
+    IoError(std::io::Error),
+}
+
+impl fmt::Display for ReadContractAddressError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HexError(hex_error) => {
+                write!(f, "failed to decode address from hex: {}", hex_error)
+            }
+            Self::IoError(io_error) => write!(
+                f,
+                "failed read address from file {}: {}",
+                CONTRACT_ADDRESS_FILE, io_error
+            ),
+        }
+    }
+}
+
+impl error::Error for ReadContractAddressError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        match self {
+            Self::HexError(hex_error) => Some(hex_error),
+            Self::IoError(io_error) => Some(io_error),
+        }
+    }
+}
+
+impl From<rustc_hex::FromHexError> for ReadContractAddressError {
+    fn from(hex_error: rustc_hex::FromHexError) -> ReadContractAddressError {
+        ReadContractAddressError::HexError(hex_error)
+    }
+}
+
+impl From<std::io::Error> for ReadContractAddressError {
+    fn from(io_error: std::io::Error) -> ReadContractAddressError {
+        ReadContractAddressError::IoError(io_error)
+    }
+}
+
+pub fn read_contract_address() -> Result<Address, ReadContractAddressError> {
+    let contract_address_hex = std::fs::read_to_string(CONTRACT_ADDRESS_FILE)?;
+    Address::from_str(&contract_address_hex).map_err(ReadContractAddressError::HexError)
+}
+
+pub type QueryResult<T> = web3::contract::QueryResult<T, <Http as Transport>::Out>;
+
+/// If a client is dropped the IO event loop is dropped, too and the client requests will error.
+pub struct Client {
+    _event_loop_handle: EventLoopHandle,
+    contract: Contract<Http>,
+}
+
+impl Client {
+    /// Creates a new client calling the ledger at the given contract address.
+    pub fn new(contract_address: Address) -> Client {
+        let (event_loop_handle, http) = web3::transports::Http::new(LOCALHOST_NODE_URL)
+            .expect("Node URL is hardcoded and valid");
+        let web3 = web3::Web3::new(http);
+        let contract_abi =
+            ethabi::Contract::load(CONTRACT_ABI_JSON).expect("ABI is hardcoded and valid");
+        let contract = Contract::new(web3.eth(), contract_address, contract_abi);
+        Client {
+            _event_loop_handle: event_loop_handle,
+            contract,
+        }
+    }
+
+    /// Creates a new client using the contract address stored in [CONTRACT_ADDRESS_FILE].
+    pub fn new_from_file() -> Result<Client, ReadContractAddressError> {
+        let contract_address = read_contract_address()?;
+        Ok(Self::new(contract_address))
+    }
+
+    pub fn ping(&self) -> QueryResult<String> {
+        self.contract
+            .query("ping", (), None, Options::default(), None)
+    }
+}

--- a/src/bin/osc-ping.rs
+++ b/src/bin/osc-ping.rs
@@ -1,21 +1,12 @@
 ///! Calls the oscoin ledger contract’s ping method and returns the output.
 use env_logger;
-use std::fs;
-use std::str;
-use std::str::FromStr;
 
-use web3::contract::{Contract, Options};
 use web3::futures::Future;
-use web3::transports::http::Http;
-use web3::types::Address;
-use web3::Web3;
 
 use clap::crate_version;
 use clap::App;
 
-/// Path to the contract Wasm code.
-const CONTRACT_ABI_PATH: &str = "./target/json/Ledger.json";
-const CONTRACT_ADDRESS_FILE: &str = "./.oscoin_ledger_address";
+use oscoin_client::Client;
 
 fn main() {
     env_logger::init();
@@ -33,30 +24,7 @@ fn main() {
         )
         .get_matches();
 
-    let web3 = prepare_web3();
-
-    let contract_address_hex = fs::read_to_string(CONTRACT_ADDRESS_FILE).unwrap();
-    let contract_address = Address::from_str(&contract_address_hex).unwrap();
-    let contract_abi = fs::read(CONTRACT_ABI_PATH).unwrap();
-    let contract =
-        Contract::from_json(web3.eth(), contract_address, contract_abi.as_ref()).unwrap();
-    let s: String = contract
-        .query(
-            "ping",
-            (),
-            oscoin::deploy::dev_account_addr(),
-            Options::default(),
-            None,
-        )
-        .wait()
-        .unwrap();
-    println!("{}", s);
-}
-
-fn prepare_web3() -> Web3<Http> {
-    let (eloop, http) =
-        web3::transports::Http::new(oscoin::deploy::NODE_URL).expect("URL is hardcoded and valid");
-    // run the event loop in the background
-    eloop.into_remote();
-    web3::Web3::new(http)
+    let client = Client::new_from_file().unwrap();
+    let pong = client.ping().wait().unwrap();
+    println!("{}", pong);
 }


### PR DESCRIPTION
We create the `oscoin_client` package and crate and move most of the code required by the `osc-ping` command there. The `oscoin_client` crate will be the home for more ledger client code.