### PR TITLE
Remove `oscoin_ledger` dependency from workspace root

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,6 @@ dependencies = [
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oscoin_client 0.1.0",
- "oscoin_ledger 0.1.0",
  "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "b2aa7336bc9bf
 env_logger = "0.6.2"
 hex = "0.3.1"
 clap = "2.31"
-oscoin_ledger = { path = "./ledger", features = ["std"] }
 oscoin_client = { path = "./client" }
 
 [workspace]
+members = ["ledger"]


### PR DESCRIPTION
We remove the `oscoin_ledger` dependency from the `oscoin` workspace root. Now we don’t need to recompile the `oscoin` binaries when the ledger changes.

We still make `oscoin_ledger` part of the workspace by adding it to `workspace.members`.