### PR TITLE
Explicitly pass sender to client methods

### DIFF
--- a/examples/project-registration.rs
+++ b/examples/project-registration.rs
@@ -5,12 +5,13 @@ use futures::Future;
 use oscoin_client::{Address, Client};
 
 fn main() {
-    let client = Client::new_from_file(oscoin_deploy::dev_account_address()).unwrap();
+    let client = Client::new_from_file().unwrap();
 
     let project_address = Address::zero();
+    let sender = oscoin_deploy::dev_account_address();
     let url = "https://example.com";
     client
-        .register_project(project_address, url.to_string())
+        .register_project(sender, project_address, url.to_string())
         .wait()
         .unwrap();
     let url2 = client.get_project_url(project_address).wait().unwrap();

--- a/src/bin/osc-ping.rs
+++ b/src/bin/osc-ping.rs
@@ -24,7 +24,7 @@ fn main() {
         )
         .get_matches();
 
-    let client = Client::new_from_file(oscoin_deploy::dev_account_address()).unwrap();
+    let client = Client::new_from_file().unwrap();
     let pong = client.ping().wait().unwrap();
     println!("{}", pong);
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -12,10 +12,10 @@ use web3::types::U256;
 #[test]
 fn counter() {
     let ledger = oscoin_deploy::deploy().unwrap();
-    let client = oscoin_client::Client::new(dev_account_address(), ledger.address());
+    let client = oscoin_client::Client::new(ledger.address());
 
     for _ in 0..10 {
-        client.counter_inc().wait().unwrap();
+        client.counter_inc(dev_account_address()).wait().unwrap();
     }
     let counter = client.counter_value().wait().unwrap();
     assert_eq!(counter, U256::from(10));
@@ -24,11 +24,15 @@ fn counter() {
 #[test]
 fn register_project() {
     let ledger = oscoin_deploy::deploy().unwrap();
-    let client = oscoin_client::Client::new(dev_account_address(), ledger.address());
+    let client = oscoin_client::Client::new(ledger.address());
 
     let url = "https://example.com";
     client
-        .register_project(dev_account_address(), url.to_string())
+        .register_project(
+            dev_account_address(),
+            dev_account_address(),
+            url.to_string(),
+        )
         .wait()
         .unwrap();
     let url2 = client


### PR DESCRIPTION
Instead of providing the transaction sender when `Client` is constructed we pass it when a method is called that requires a sender. (These are the methods that submit transactions and update the ledger.)

This allows consumers to use the client even if they don’t have an account yet, for example if they want to create an account.