### PR TITLE
Project registration returns ID

### DIFF
--- a/ledger-spec/src/error.rs
+++ b/ledger-spec/src/error.rs
@@ -15,9 +15,6 @@ pub enum TransferError {
 /// Oscoin ledger (`register` transaction). Not exhaustive, but should cover
 /// most common cases.
 pub enum RegisterProjectError {
-    /// A project has already been registered at the given account identifier.
-    AccountIdInUseError,
-
     /// The canonical source URL used to register the project is invalid.
     ///
     /// The 1.0 version of the whitepaper establishes only one condition for

--- a/ledger-spec/src/lib.rs
+++ b/ledger-spec/src/lib.rs
@@ -27,24 +27,21 @@ pub trait LedgerTransactions {
         amount: types::Oscoin,
     ) -> Result<(), error::TransferError>;
 
-    /// Registering a project in the Oscoin Ledger.
+    /// Registers a project on the Oscoin Ledger and returns the new project’s ID.
     ///
-    /// This transaction's inclusion in the ledger is also subject to
-    /// discussion as there is still an unclear boundary between the account
-    /// layer and the ledger. This matter can be revisited.
+    /// The transaction’s sender account becomes the initial maintainer of the project.
+    ///
+    /// The project ID is computed by hashing the sender’s nonce and the arguments. In the current
+    /// implementation we use ethereum’s contract creation logic which generates the project ID.
     fn register_project(
-        // Account identifier of the project to be registered.
-        project_account: types::AccountId,
         // Canonical source URL of the project to be registered.
         project_source_url: types::URL,
-    ) -> Result<(), error::RegisterProjectError>;
+    ) -> Result<types::ProjectId, error::RegisterProjectError>;
 
     /// Given a certain project, `addkey` adds a key to its set of keys (c.f.
     /// section 4.4.1 of the whitepaper).
     fn addkey(
-        // Account identifier of the project to which a new maintainer is to be
-        // added.
-        project_account: types::AccountId,
+        id: types::ProjectId,
         // Account identifier of the maintainer to be added to the project's
         // key set.
         maintainer_key: types::AccountId,
@@ -53,9 +50,7 @@ pub trait LedgerTransactions {
     /// Given a certain project, `removekey` removes a key from its set of
     /// keys (c.f. section 4.4.1 of the whitepaper).
     fn removekey(
-        // Account identifier of the project from which a maintainer is to be
-        // removed.
-        project_account: types::AccountId,
+        id: types::ProjectId,
         // Account identifier of the maintainer to be removed from the
         // project's key set.
         maintainer_key: types::AccountId,
@@ -65,10 +60,7 @@ pub trait LedgerTransactions {
     ///
     /// As is the case above, this transaction may also be handled outside the
     /// ledger.
-    fn unregister_project(
-        // Account identifier of the project to be removed from the ledger.
-        project_account: types::AccountId,
-    ) -> Result<(), error::UnregisterProjectError>;
+    fn unregister_project(id: types::ProjectId) -> Result<(), error::UnregisterProjectError>;
 
     /// Checkpointing a project in Oscoin's ledger.
     fn checkpoint(

--- a/ledger-spec/src/types.rs
+++ b/ledger-spec/src/types.rs
@@ -11,6 +11,12 @@ pub struct Address;
 /// diverge.
 pub type AccountId = Address;
 
+/// Identifier for a project.
+///
+/// At present it is assumed to be the same as `Address`, but will eventually
+/// diverge.
+pub type ProjectId = Address;
+
 /// Type for Ledger public keys. Its specific data structure is not
 /// important here, just as it is with `Address`es.
 pub struct PublicKey;


### PR DESCRIPTION
_Based on #21_

With this change projects are not associated with accounts anymore. Projects will not be identified and addressed by there associated account but by there project IDs. In particular project registration now returns a project ID instead of accepting a project account parameter.

The previous behavior raised a lot of questions around the special status of an account associated with a project and the account’s private key.

* Would the private key control all the funds of the project?
* What permissions does this private key have and how do they differ from other project member’s permissions that are not associated with that private key?
* What happens when ownership is transfered? We cannot guarantee that the previous owner gives up the private key.
* Would the `register_account` transaction be sent from the account associated with a project?