### PR TITLE
Compile ledger to Wasm with no_std

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -535,6 +535,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -1268,6 +1271,11 @@ version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "spin"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1970,6 +1978,7 @@ dependencies = [
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum spin 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbdb51a221842709c2dd65b62ad4b78289fc3e706a02c17a26104528b6aa7837"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -12,7 +12,7 @@ pwasm-std = "0.13"
 pwasm-ethereum = "0.8"
 pwasm-abi = "0.2"
 pwasm-abi-derive = "0.2"
-lazy_static = "1.3.0"
+lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 
 [lib]
 crate-type = ["cdylib"]

--- a/tools/build-ledger-wasm
+++ b/tools/build-ledger-wasm
@@ -7,6 +7,8 @@
 
 set -euo pipefail
 
+project_root=$(dirname $BASH_SOURCE)/..
+
 # Rust flags to make the Wasm output small.
 rust_flags="${RUSTFLAGS:-""}"
 rust_flags+=" -C panic=abort"
@@ -17,9 +19,12 @@ rust_flags+=" -C opt-level=z"
 # produces invalid Wasm.
 rust_flags+=" -C link-args=-zstack-size=65536"
 
+# NOTE: We cannot use `cargo build --project oscoin_ledger` because
+# `--no-default-features` is not respected.
+# See https://github.com/rust-lang/cargo/issues/5015
 RUSTFLAGS=$rust_flags\
   cargo build \
-  --package oscoin_ledger \
+  --manifest-path $project_root/ledger/Cargo.toml \
   --no-default-features \
   --release \
   --target wasm32-unknown-unknown


### PR DESCRIPTION
Before this change the ledger code was compiled _without_ `no_std` to the Wasm target. This did not cause problems yet since we did not use any `std` code. However, in the future we would have run into issues if we inadvertently used `std` code.

The reason why `no_std` was not enabled was that the `--no-default-features` flag was not respected in `tool/build-ledger-wasm` because of https://github.com/rust-lang/cargo/issues/5015.