### PR TITLE
Only upload target/cargo cache once

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ jobs:
 
       - save_cache:
           # "epoch" is here to ensure that we upload a new cache on each build
-          key: cargo-target-v1-{{ checksum "Cargo.lock" }}-{{ epoch }}
+          key: cargo-target-v1-{{ checksum "Cargo.lock" }}
           paths:
             - "~/.cargo"
             - "./target"


### PR DESCRIPTION
Instead of updating the cache of `~/.cargo` and `./target` for _every_ build we only upload it once for a specific `Cargo.lock` file.

This means that in the worst case we need to recompile all artifacts generated from the source code in the repository even if there is a cache. (Note that we never need to recompile dependencies because if they change `Cargo.lock` changes.) However, recompiling the project code is fast enough, in fact it is faster than uploading the new cache every time. Also note that even with caching we often need to recompile large portions of the code. The new setup also prevents the cached `./target` directory from growing indefinitely.