### PR TITLE
Separate package to build oscoin_ledger for pwasm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/*/target
-/target
+**/target
 **/*.rs.bk
 .oscoin_ledger_address

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -762,6 +762,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "oscoin_ledger_pwasm"
+version = "0.1.0"
+dependencies = [
+ "oscoin_ledger 0.1.0",
+]
+
+[[package]]
 name = "owning_ref"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,4 @@ web3 = "0.8.0"
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "b2aa7336bc9bf192f7959e79525a6d2667ff4c85" }
 
 [workspace]
-members = ["deploy", "ledger", "ledger-spec"]
+members = ["deploy", "ledger", "ledger-spec", "ledger/pwasm"]

--- a/deploy/src/lib.rs
+++ b/deploy/src/lib.rs
@@ -15,8 +15,8 @@ use web3::Web3;
 /// Maximum gas used to deploy the contract
 pub const DEPLOY_GAS: u32 = 18_000_000;
 
-/// Path to the contract Wasm code. Is `./target/oscoin_ledger.wasm`.
-pub const CONTRACT_CODE_PATH: &str = "./target/oscoin_ledger.wasm";
+/// Path to the contract Wasm code. Is `./target/oscoin_ledger_pwasm.wasm`.
+pub const CONTRACT_CODE_PATH: &str = "./target/oscoin_ledger_pwasm.wasm";
 
 /// Contract ABI JSON. This is empty because there are no constructor arguments.
 const CONTRACT_ABI: &[u8] = b"[]";

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -14,9 +14,6 @@ pwasm-abi = "0.2"
 pwasm-abi-derive = "0.2"
 lazy_static = "1.3.0"
 
-[lib]
-crate-type = ["cdylib"]
-
 [features]
 default = ["std"]
 std = ["pwasm-std/std", "pwasm-ethereum/std"]

--- a/ledger/pwasm/Cargo.toml
+++ b/ledger/pwasm/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "oscoin_ledger_pwasm"
+description = "Wraps oscoin_ledger to compile it to Parity Wasm"
+version = "0.1.0"
+authors = [
+  "Alexandre Baldé <alexandre@monadic.xyz>",
+  "Thomas Scholtes <thomas@monadic.xyz>"
+]
+edition = "2018"
+
+[dependencies]
+oscoin_ledger = { path = "../" }
+
+[lib]
+crate-type = ["cdylib"]
+

--- a/ledger/pwasm/src/lib.rs
+++ b/ledger/pwasm/src/lib.rs
@@ -1,0 +1,7 @@
+#[no_mangle]
+pub fn call() {
+    oscoin_ledger::call();
+}
+
+#[no_mangle]
+pub fn deploy() {}

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -13,16 +13,12 @@ pub mod storage;
 
 use storage::Storage;
 
-#[no_mangle]
 pub fn call() {
     let mut endpoint = LedgerEndpoint::new(Ledger_ {
         env: Storage { env: pwasm::Pwasm },
     });
     pwasm_ethereum::ret(&endpoint.dispatch(&pwasm_ethereum::input()));
 }
-
-#[no_mangle]
-pub fn deploy() {}
 
 #[eth_abi(LedgerEndpoint, LedgerClient)]
 pub trait Ledger {

--- a/ledger/src/pwasm.rs
+++ b/ledger/src/pwasm.rs
@@ -38,7 +38,8 @@ use std::collections::HashMap;
 ///
 /// Create an empty [TestEnv] with
 /// ```
-/// let testEnv: TestEnv = Default::default()
+/// # use oscoin_ledger::pwasm::*;
+/// let testEnv = TestEnv::default();
 /// ```
 #[cfg(any(feature = "std", test))]
 #[derive(Default)]

--- a/tools/build-ledger-wasm
+++ b/tools/build-ledger-wasm
@@ -17,18 +17,22 @@ rust_flags+=" -C opt-level=z"
 # produces invalid Wasm.
 rust_flags+=" -C link-args=-zstack-size=65536"
 
+target=wasm32-unknown-unknown
+name=oscoin_ledger_pwasm
+
 RUSTFLAGS=$rust_flags\
   cargo build \
-  --package oscoin_ledger \
-  --no-default-features \
+  --package $name \
   --release \
-  --target wasm32-unknown-unknown
+  --target $target
 
-wasm-build --target=wasm32-unknown-unknown ./target oscoin_ledger
+wasm-build --target $target ./target $name
 
 if which wasm2wat >/dev/null 2>&1 ; then
   wasm2wat \
-    ./target/wasm32-unknown-unknown/release/oscoin_ledger.wasm \
-    > ./target/wasm32-unknown-unknown/release/oscoin_ledger.wat
-  wasm2wat ./target/oscoin_ledger.wasm > ./target/oscoin_ledger.wat
+    ./target/$target/release/$name.wasm \
+    > ./target/$target/release/$name.wat
+  wasm2wat \
+    ./target/$name.wasm \
+    > ./target/$name.wat
 fi


### PR DESCRIPTION
We create a new package `oscoin_ledger_pwasm` that we use to compile the ledger to Parity Wasm. This package is a simple wrapper for `oscoin_ledger`. This allows us to compile the `oscoin_ledger` with crate type `lib`. This enables us to compile the doc tests and reuse `oscoin_ledger` in other crates.