### PR TITLE
Use patched version of wasm-build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,7 +31,7 @@ jobs:
       - run:
           name: Install dependencies
           command: |
-            command -v wasm-build || cargo install pwasm-utils-cli --version 0.10.0 --bin wasm-build
+            cargo build --package pwasm-utils-cli --bin wasm-build
 
             wget https://releases.parity.io/ethereum/v2.6.0/x86_64-unknown-linux-gnu/parity
             echo "1b50cabc8ce54983d1b10be4c4f5887ff4ecfe63177e6c49cde819a563fb9d96  parity" > parity.sum

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -328,6 +340,11 @@ dependencies = [
  "libc 0.2.62 (registry+https://github.com/rust-lang/crates.io-index)",
  "wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "glob"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "h2"
@@ -723,6 +740,7 @@ dependencies = [
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "oscoin_client 0.1.0",
  "oscoin_deploy 0.1.0",
+ "pwasm-utils-cli 0.10.0 (git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages)",
  "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)",
 ]
 
@@ -784,6 +802,11 @@ dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "parity-wasm"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "parking_lot"
@@ -934,6 +957,30 @@ dependencies = [
  "pwasm-libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uint 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pwasm-utils"
+version = "0.10.0"
+source = "git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages#90f813ddbd018e38d860ebd452caacd027c5f74f"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "pwasm-utils-cli"
+version = "0.10.0"
+source = "git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages#90f813ddbd018e38d860ebd452caacd027c5f74f"
+dependencies = [
+ "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pwasm-utils 0.10.0 (git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages)",
 ]
 
 [[package]]
@@ -1860,6 +1907,7 @@ dependencies = [
 "checksum crunchy 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 "checksum derive_more 0.15.0 (registry+https://github.com/rust-lang/crates.io-index)" = "7a141330240c921ec6d074a3e188a7c7ef95668bb95e7d44fa0e5778ec2a7afe"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)" = "aafcde04e90a5226a6443b7aabdb016ba2f8307c847d524724bd9b346dd1a2d3"
 "checksum error-chain 0.12.1 (registry+https://github.com/rust-lang/crates.io-index)" = "3ab49e9dcb602294bc42f9a7dfc9bc6e936fca4418ea300dbfb84fe16de0b7d9"
 "checksum ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ebdeeea85a6d217b9fcc862906d7e283c047e04114165c433756baf5dce00a6c"
@@ -1875,6 +1923,7 @@ dependencies = [
 "checksum futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "45dc39533a6cae6da2b56da48edae506bb767ec07370f86f70fc062e9d435869"
 "checksum futures-cpupool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "ab90cde24b3319636588d0c35fe03b1333857621051837ed769faefb4c2162e4"
 "checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
+"checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
@@ -1918,6 +1967,7 @@ dependencies = [
 "checksum openssl-sys 0.9.49 (registry+https://github.com/rust-lang/crates.io-index)" = "f4fad9e54bd23bd4cbbe48fdc08a1b8091707ac869ef8508edea2fec77dcc884"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parity-codec 3.5.4 (registry+https://github.com/rust-lang/crates.io-index)" = "2b9df1283109f542d8852cd6b30e9341acc2137481eb6157d2e62af68b0afec9"
+"checksum parity-wasm 0.39.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17cf2b50c5bd3badc0e148a4dbbe5592d553c38a430270a0fa2f67bf0ccd477b"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f842b1982eb6c2fe34036a4fbfb06dd185a3f5c8edfaacdf7d1ea10b07de6252"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
@@ -1934,6 +1984,8 @@ dependencies = [
 "checksum pwasm-ethereum 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b5509e67ee47ec62bdbd1c32a6949931adbe2e12a460bb45e5dc46593fdc71c"
 "checksum pwasm-libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f31d0f66477d84afab3591c08587188b46fd1ab93c1e1cb5d23f683fcc2a92b1"
 "checksum pwasm-std 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7fa5ab4637584074a26c7fe9b3516ae887a98539516d6a7075afbef5c404be5d"
+"checksum pwasm-utils 0.10.0 (git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages)" = "<none>"
+"checksum pwasm-utils-cli 0.10.0 (git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages)" = "<none>"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)" = "6ce23b6b870e8f94f81fb0a363d65d86675884b34a09043c81e5562f11c1f8e1"
 "checksum quote 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "053a8c8bcc71fcce321828dc897a98ab9760bef03a4fc36693c231e5b3216cfe"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,11 +17,16 @@ futures = "0.1.28"
 hex = "0.3.1"
 web3 = "0.8.0"
 
+[dev-dependencies]
+pwasm-utils-cli = "0.10.0"
+
 
 [patch.crates-io]
 # We require the patch https://github.com/tomusdrw/rust-web3/pull/242.
 # Once a new version of web3 is released we can update it.
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "b2aa7336bc9bf192f7959e79525a6d2667ff4c85" }
+# See https://github.com/paritytech/wasm-utils/pull/132
+pwasm-utils-cli = { git = "https://github.com/oscoin/wasm-utils.git", branch = "pack-min-pages" }
 
 [workspace]
 members = ["deploy", "ledger", "ledger-spec", "ledger/pwasm"]

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Requirements
 
 * [`rustup`](https://github.com/rust-lang/rustup.rs/)
 * [Latest version][peth-release] of the Parity Ethereum node on the PATH
-* `cargo install pwasm-utils-cli --version 0.10.0 --bin wasm-build`
+* `cargo build --package pwasm-utils-cli --bin wasm-build`
 * `rustup target add wasm32-unknown-unknown`
 
 [peth-release]: https://github.com/paritytech/parity-ethereum/releases/latest

--- a/tools/build-ledger-wasm
+++ b/tools/build-ledger-wasm
@@ -26,7 +26,10 @@ RUSTFLAGS=$rust_flags\
   --release \
   --target $target
 
-wasm-build --target $target ./target $name
+wasm-build \
+  --target $target \
+  --save-raw ./target/${name}_raw.wasm \
+  ./target $name
 
 if which wasm2wat >/dev/null 2>&1 ; then
   wasm2wat \
@@ -35,4 +38,7 @@ if which wasm2wat >/dev/null 2>&1 ; then
   wasm2wat \
     ./target/$name.wasm \
     > ./target/$name.wat
+  wasm2wat \
+    ./target/${name}_raw.wasm \
+    > ./target/${name}_raw.wat
 fi

--- a/tools/build-ledger-wasm
+++ b/tools/build-ledger-wasm
@@ -26,7 +26,7 @@ RUSTFLAGS=$rust_flags\
   --release \
   --target $target
 
-wasm-build \
+./target/debug/wasm-build \
   --target $target \
   --save-raw ./target/${name}_raw.wasm \
   ./target $name


### PR DESCRIPTION
Use patched version of wasm-build The patch fixes an issue where wasm contracts failed to deploy if the code size was too large.

We also change the procedure with which `wasm-build` is installed. Instead of using the global `cargo install` command we use the local version.

We also output the “raw” Wasm contract when running `wasm-build`. This is the contract that is deployed where as the normal output is the constructor code that deploys the contract.