### PR TITLE
Replace pwasm-abi with RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,11 @@ dependencies = [
 ]
 
 [[package]]
+name = "half"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "heapsize"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -552,6 +557,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "libc"
@@ -754,7 +762,10 @@ version = "0.1.0"
 dependencies = [
  "ethabi 8.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "oscoin_ledger 0.1.0",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)",
  "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)",
 ]
 
@@ -774,9 +785,10 @@ version = "0.1.0"
 dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-abi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "pwasm-abi-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-ethereum 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-std 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)",
 ]
 
 [[package]]
@@ -903,22 +915,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-std 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "pwasm-abi-derive"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "fixed-hash 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
- "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "syn 0.15.44 (registry+https://github.com/rust-lang/crates.io-index)",
- "tiny-keccak 1.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1282,6 +1278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_cbor"
+version = "0.10.0"
+source = "git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std#6f7020ac083820bfa64d52e063e676b0eab715a4"
+dependencies = [
+ "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "serde_derive"
 version = "1.0.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1319,6 +1325,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "smallvec"
 version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "spin"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1925,6 +1936,7 @@ dependencies = [
 "checksum getrandom 0.1.11 (registry+https://github.com/rust-lang/crates.io-index)" = "fc344b02d3868feb131e8b5fe2b9b0a1cc42942679af493061fc13b853243872"
 "checksum glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "8be18de09a56b60ed0edf84bc9df007e30040691af7acd1c41874faac5895bfb"
 "checksum h2 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)" = "a5b34c246847f938a410a03c5458c7fee2274436675e76d8b903c08efc29c462"
+"checksum half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9353c2a89d550b58fa0061d8ed8d002a7d8cdf2494eb0e432859bd3a9e543836"
 "checksum heapsize 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "1679e6ea370dee694f91f1dc469bf94cf8f52051d147aec3e1f9497c6fc22461"
 "checksum hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)" = "805026a5d0141ffc30abb3be3173848ad46a1b1664fe632428479619a3644d77"
 "checksum http 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "372bcb56f939e449117fb0869c2e8fd8753a8223d92a172c6e808cf123a5b6e4"
@@ -1979,7 +1991,6 @@ dependencies = [
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum proc-macro2 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4c5c2380ae88876faae57698be9e9775e3544decad214599c3a6266cca6ac802"
 "checksum pwasm-abi 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "3eccaec239b0e2967578c97a589a08893abe5d3ada2479fde6d04e0ec32c9993"
-"checksum pwasm-abi-derive 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "c042abcfe7caf5d493102dd9751eefa755419cb11b425f30a8f490fdac147a0d"
 "checksum pwasm-alloc 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20c219f82ecb45feafa64e22a1f354462243f5be05eb1f4722a302e79ff7e3b9"
 "checksum pwasm-ethereum 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8b5509e67ee47ec62bdbd1c32a6949931adbe2e12a460bb45e5dc46593fdc71c"
 "checksum pwasm-libc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f31d0f66477d84afab3591c08587188b46fd1ab93c1e1cb5d23f683fcc2a92b1"
@@ -2023,12 +2034,14 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
+"checksum serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)" = "<none>"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"
 "checksum slab 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "17b4fcaed89ab08ef143da37bc52adbcc04d4a69014f4c1208d6b51f0c47bc23"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"
+"checksum spin 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
 "checksum static_assertions 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "c19be23126415861cb3a23e501d34a708f7f9b2183c5252d690941c2e69199d5"
 "checksum string 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "d24114bfcceb867ca7f71a0d3fe45d45619ec47a6fbfa98cb14e14250bfa5d6d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,8 @@ pwasm-utils-cli = "0.10.0"
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "b2aa7336bc9bf192f7959e79525a6d2667ff4c85" }
 # See https://github.com/paritytech/wasm-utils/pull/132
 pwasm-utils-cli = { git = "https://github.com/oscoin/wasm-utils.git", branch = "pack-min-pages" }
+# See https://github.com/oscoin/oscoin-parity-wasm-prototype/pull/45
+serde_cbor = { git = "https://github.com/geigerzaehler/cbor.git", branch = "to-vec-no-std" }
 
 [workspace]
 members = ["deploy", "ledger", "ledger-spec", "ledger/pwasm"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -6,7 +6,11 @@ authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
 edition = "2018"
 
 [dependencies]
-web3 = "0.8.0"
+oscoin_ledger = { path = "../ledger" }
+
 ethabi = "8.0.0"
-rustc-hex = "2.0.1"
 futures = "0.1.28"
+rustc-hex = "2.0.1"
+serde = "1.0"
+serde_cbor = "=0.10.0"
+web3 = "0.8.0"

--- a/deploy/src/lib.rs
+++ b/deploy/src/lib.rs
@@ -13,7 +13,7 @@ use web3::types::Address;
 use web3::Web3;
 
 /// Maximum gas used to deploy the contract
-pub const DEPLOY_GAS: u32 = 18_000_000;
+pub const DEPLOY_GAS: u32 = 100_000_000;
 
 /// Path to the contract Wasm code. Is `./target/oscoin_ledger_pwasm.wasm`.
 pub const CONTRACT_CODE_PATH: &str = "./target/oscoin_ledger_pwasm.wasm";

--- a/dev-node/chainspec.json
+++ b/dev-node/chainspec.json
@@ -35,7 +35,7 @@
 		"timestamp": "0x00",
 		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
 		"extraData": "0x",
-		"gasLimit": "0x7A12000"
+		"gasLimit": "0xAA12000"
 	},
 	"accounts": {
 		"0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -17,3 +17,6 @@ lazy_static = "1.3.0"
 [features]
 default = ["std"]
 std = ["pwasm-std/std", "pwasm-ethereum/std"]
+# If enabled panics will provide the formatted message to the Wasm
+# runtime. This simplifies debugging.
+panic_with_msg = [ "pwasm-std/panic_with_msg" ]

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -11,12 +11,18 @@ edition = "2018"
 pwasm-std = "0.13"
 pwasm-ethereum = "0.8"
 pwasm-abi = "0.2"
-pwasm-abi-derive = "0.2"
-lazy_static = "1.3.0"
+lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
+serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
+serde_cbor = { version = "=0.10.0", default-features = false, features = ["alloc"] }
 
 [features]
 default = ["std"]
-std = ["pwasm-std/std", "pwasm-ethereum/std"]
+std = [
+  "pwasm-std/std",
+  "pwasm-ethereum/std",
+  "serde_cbor/std",
+  "serde/std",
+  ]
 # If enabled panics will provide the formatted message to the Wasm
 # runtime. This simplifies debugging.
 panic_with_msg = [ "pwasm-std/panic_with_msg" ]

--- a/ledger/pwasm/Cargo.toml
+++ b/ledger/pwasm/Cargo.toml
@@ -9,8 +9,7 @@ authors = [
 edition = "2018"
 
 [dependencies]
-oscoin_ledger = { path = "../" }
+oscoin_ledger = { path = "../", default-features = false, features = ["panic_with_msg"] }
 
 [lib]
 crate-type = ["cdylib"]
-

--- a/ledger/pwasm/src/lib.rs
+++ b/ledger/pwasm/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 #[no_mangle]
 pub fn call() {
     oscoin_ledger::call();

--- a/ledger/src/interface.rs
+++ b/ledger/src/interface.rs
@@ -1,0 +1,99 @@
+//! Abstract interfaces for the ledger and related types.
+//!
+//! The abstract leder interface is encoded in the [Ledger] trait.
+//!
+//! Calls to the ledger a reified in the [Call] enum. Each ledger method has a corresponding
+//! [Query] or [Update] constructor. With [dispatch] the method corresponding to a given [Call] is
+//! called on a [Ledger] implementation.
+use crate::pwasm::String;
+use alloc::prelude::v1::*;
+use serde::{Deserialize, Serialize};
+
+pub type ProjectId = [u8; 20];
+
+/// Public interface of the oscoin ledger
+pub trait Ledger {
+    fn ping(&mut self) -> String;
+
+    fn counter_inc(&mut self);
+
+    fn counter_value(&mut self) -> u32;
+
+    fn register_project(&mut self, project_id: ProjectId, url: String);
+
+    fn get_project_url(&mut self, project_id: ProjectId) -> String;
+}
+
+/// Represents a call to a ledger method. Either a [Query] or a [Update].
+///
+/// Calls are serialized to byte vectors with [Call::serialize].
+///
+/// Each [Call] corresponds to a method on [Ledger].
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Call {
+    Query(Query),
+    Update(Update),
+}
+
+/// Reified non-mutating call to the ledger
+///
+/// Each [Query] corresponds to a method on [Ledger].
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Query {
+    Ping,
+    CounterValue,
+    GetProjectUrl { project_id: ProjectId },
+}
+
+/// Reified update to the ledger
+///
+/// Each [Update] corresponds to a method on [Ledger].
+#[derive(Serialize, Deserialize, Clone)]
+pub enum Update {
+    CounterInc,
+    RegisterProject { project_id: ProjectId, url: String },
+}
+
+impl Call {
+    pub fn serialize(&self) -> Vec<u8> {
+        serde_cbor::to_vec(&self).expect("CBOR serialization to Vec always succeeds")
+    }
+
+    pub fn deserialize(data: &[u8]) -> serde_cbor::Result<Self> {
+        let call = serde_cbor::from_slice::<Call>(data)?;
+        Ok(call.clone())
+    }
+}
+
+impl From<Query> for Call {
+    fn from(query: Query) -> Call {
+        Call::Query(query)
+    }
+}
+
+impl From<Update> for Call {
+    fn from(update: Update) -> Call {
+        Call::Update(update)
+    }
+}
+
+/// Calls the `ledger`’s method corresponding to `call` and returns the serialized result of the
+/// method call.
+pub fn dispatch(mut ledger: impl Ledger, call: Call) -> Vec<u8> {
+    let res = match call {
+        Call::Query(query) => match query {
+            Query::Ping => serde_cbor::to_vec(&ledger.ping()),
+            Query::CounterValue => serde_cbor::to_vec(&ledger.counter_value()),
+            Query::GetProjectUrl { project_id } => {
+                serde_cbor::to_vec(&ledger.get_project_url(project_id))
+            }
+        },
+        Call::Update(update) => match update {
+            Update::CounterInc => serde_cbor::to_vec(&ledger.counter_inc()),
+            Update::RegisterProject { project_id, url } => {
+                serde_cbor::to_vec(&ledger.register_project(project_id, url))
+            }
+        },
+    };
+    res.expect("CBOR serialization never fails")
+}

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -7,7 +7,6 @@
 //! counter.
 use oscoin_deploy::dev_account_address;
 use web3::futures::Future;
-use web3::types::U256;
 
 #[test]
 fn counter() {
@@ -18,7 +17,7 @@ fn counter() {
         client.counter_inc(dev_account_address()).wait().unwrap();
     }
     let counter = client.counter_value().wait().unwrap();
-    assert_eq!(counter, U256::from(10));
+    assert_eq!(counter, 10);
 }
 
 #[test]

--- a/tools/build-ledger-wasm
+++ b/tools/build-ledger-wasm
@@ -20,9 +20,12 @@ rust_flags+=" -C link-args=-zstack-size=65536"
 target=wasm32-unknown-unknown
 name=oscoin_ledger_pwasm
 
+# We need to use --manifest-path instead of --package. Otherwise the
+# library is build with the workspace configuration and `no_std` is
+# somehow disabled.
 RUSTFLAGS=$rust_flags\
   cargo build \
-  --package $name \
+  --manifest-path ledger/pwasm/Cargo.toml \
   --release \
   --target $target
 


### PR DESCRIPTION
Replace `pwasm-abi` and `pwasm-abi-derive` with our own RPC/ABI mechanism based on `serde_cbor`.

Fixes #41