### PR TITLE
Dynamic environment for storage

### DIFF
--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -14,7 +14,7 @@ use storage::Storage;
 
 pub fn call() {
     let ledger = Ledger_ {
-        env: Storage { env: pwasm::Pwasm },
+        env: Storage::new(pwasm::Pwasm),
     };
     let call_result = Call::deserialize(pwasm_ethereum::input().as_slice());
     let call = match call_result {
@@ -28,8 +28,8 @@ pub fn call() {
 }
 
 /// Implements [Ledger] backed by [Storage].
-pub struct Ledger_<E: pwasm::Env> {
-    pub env: Storage<E>,
+pub struct Ledger_ {
+    pub env: Storage,
 }
 
 lazy_static::lazy_static! {
@@ -39,7 +39,7 @@ lazy_static::lazy_static! {
         );
 }
 
-impl<E: pwasm::Env> Ledger for Ledger_<E> {
+impl Ledger for Ledger_ {
     fn ping(&mut self) -> String {
         String::from("pong")
     }
@@ -96,11 +96,9 @@ mod test {
         assert_eq!(url, expected_url);
     }
 
-    fn new_ledger() -> Ledger_<pwasm::TestEnv> {
+    fn new_ledger() -> Ledger_ {
         Ledger_ {
-            env: Storage {
-                env: pwasm::TestEnv::new(),
-            },
+            env: Storage::new(pwasm::TestEnv::new()),
         }
     }
 }

--- a/ledger/src/storage.rs
+++ b/ledger/src/storage.rs
@@ -5,22 +5,29 @@
 //!
 //! ```
 //! # use oscoin_ledger::storage::Storage;
-//! let mut storage = Storage { env: oscoin_ledger::pwasm::TestEnv::new() };
+//! let mut storage = Storage::new(oscoin_ledger::pwasm::TestEnv::new());
 //! let some_bytes = Vec::from(b"abcdef" as &[u8]);
 //! storage.write("key".as_ref(), some_bytes.as_ref());
 //! assert_eq!(some_bytes, storage.read("key".as_ref()));
 //! ```
 use crate::pwasm;
 use crate::pwasm::{Vec, H256, U256};
+use alloc::prelude::v1::*;
 
-pub struct Storage<E: pwasm::Env> {
-    pub env: E,
+pub struct Storage {
+    env: Box<dyn pwasm::Env + 'static>,
+}
+
+impl Storage {
+    pub fn new(env: impl pwasm::Env + 'static) -> Storage {
+        Storage { env: Box::new(env) }
+    }
 }
 
 /// Number of bytes that can be stored with the pwasm environment
 const CHUNK_SIZE: usize = 32;
 
-impl<E: pwasm::Env> Storage<E> {
+impl Storage {
     pub fn write(&mut self, key: &[u8], value: &[u8]) {
         let key_hash = U256::from(pwasm_std::keccak(key));
         let u256_len = U256::from(value.len());


### PR DESCRIPTION
Instead of using a type parameter for the environment for Storage we use a trait object. This simplifies the use of storage and provides better abstraction.