### PR TITLE
Patch web3 to make sign_transaction work

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -749,7 +749,7 @@ dependencies = [
  "oscoin_client 0.1.0",
  "oscoin_deploy 0.1.0",
  "pwasm-utils-cli 0.10.0 (git+https://github.com/oscoin/wasm-utils.git?branch=pack-min-pages)",
- "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)",
+ "web3 0.8.0 (git+https://github.com/geigerzaehler/rust-web3.git?rev=b5f3c3bbca902fce551f99af246a498d42c911fb)",
 ]
 
 [[package]]
@@ -766,7 +766,7 @@ dependencies = [
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)",
- "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)",
+ "web3 0.8.0 (git+https://github.com/geigerzaehler/rust-web3.git?rev=b5f3c3bbca902fce551f99af246a498d42c911fb)",
 ]
 
 [[package]]
@@ -776,7 +776,7 @@ dependencies = [
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.6.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)",
+ "web3 0.8.0 (git+https://github.com/geigerzaehler/rust-web3.git?rev=b5f3c3bbca902fce551f99af246a498d42c911fb)",
 ]
 
 [[package]]
@@ -1780,7 +1780,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "web3"
 version = "0.8.0"
-source = "git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85#b2aa7336bc9bf192f7959e79525a6d2667ff4c85"
+source = "git+https://github.com/geigerzaehler/rust-web3.git?rev=b5f3c3bbca902fce551f99af246a498d42c911fb#b5f3c3bbca902fce551f99af246a498d42c911fb"
 dependencies = [
  "arrayvec 0.4.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2089,7 +2089,7 @@ dependencies = [
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum want 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "b6395efa4784b027708f7451087e647ec73cc74f5d9bc2e418404248d679a230"
 "checksum wasi 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "fd5442abcac6525a045cc8c795aedb60da7a2e5e89c7bf18a0d5357849bb23c7"
-"checksum web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=b2aa7336bc9bf192f7959e79525a6d2667ff4c85)" = "<none>"
+"checksum web3 0.8.0 (git+https://github.com/geigerzaehler/rust-web3.git?rev=b5f3c3bbca902fce551f99af246a498d42c911fb)" = "<none>"
 "checksum websocket 0.21.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c9faed2bff8af2ea6b9f8b917d3d00b467583f6781fe3def174a9e33c879703"
 "checksum wee_alloc 0.4.5 (registry+https://github.com/rust-lang/crates.io-index)" = "dbb3b5a6b2bb17cb6ad44a2e68a43e8d2722c997da10e928665c72ec6c0a0b8e"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,10 @@ pwasm-utils-cli = "0.10.0"
 
 
 [patch.crates-io]
-# We require the patch https://github.com/tomusdrw/rust-web3/pull/242.
+# We require the patches https://github.com/tomusdrw/rust-web3/pull/242
+# and https://github.com/tomusdrw/rust-web3/pull/250
 # Once a new version of web3 is released we can update it.
-web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "b2aa7336bc9bf192f7959e79525a6d2667ff4c85" }
+web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "db4443ee16765c0754a87d9359d8f6b9e0c04d3a" }
 # See https://github.com/paritytech/wasm-utils/pull/132
 pwasm-utils-cli = { git = "https://github.com/oscoin/wasm-utils.git", branch = "pack-min-pages" }
 # See https://github.com/oscoin/oscoin-parity-wasm-prototype/pull/45

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -6,7 +6,7 @@ authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
 edition = "2018"
 
 [dependencies]
-web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "b2aa7336bc9bf192f7959e79525a6d2667ff4c85" }
+web3 = "0.8.0"
 env_logger = "0.6.2"
 hex = "0.3.1"
 clap = "2.31"


### PR DESCRIPTION
Patches web3 with https://github.com/tomusdrw/rust-web3/pull/250 so that `sign_transaction()` works.