### PR TITLE
Introduce Project struct

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -132,8 +132,8 @@ impl Client {
         )
     }
 
-    pub fn get_project_url(&self, account: Address) -> QueryResult<String> {
-        self.query(LedgerQuery::GetProjectUrl {
+    pub fn get_project(&self, account: Address) -> QueryResult<Option<oscoin_ledger::Project>> {
+        self.query(LedgerQuery::GetProject {
             project_id: account.to_fixed_bytes(),
         })
     }

--- a/examples/project-registration.rs
+++ b/examples/project-registration.rs
@@ -14,6 +14,6 @@ fn main() {
         .register_project(sender, project_address, url.to_string())
         .wait()
         .unwrap();
-    let url2 = client.get_project_url(project_address).wait().unwrap();
-    assert_eq!(url, url2);
+    let project = client.get_project(project_address).wait().unwrap().unwrap();
+    assert_eq!(url, project.url);
 }

--- a/ledger/src/interface.rs
+++ b/ledger/src/interface.rs
@@ -11,6 +11,11 @@ use serde::{Deserialize, Serialize};
 
 pub type ProjectId = [u8; 20];
 
+#[derive(Serialize, Deserialize, Debug)]
+pub struct Project {
+    pub url: String,
+}
+
 /// Public interface of the oscoin ledger
 pub trait Ledger {
     fn ping(&mut self) -> String;
@@ -21,7 +26,7 @@ pub trait Ledger {
 
     fn register_project(&mut self, project_id: ProjectId, url: String);
 
-    fn get_project_url(&mut self, project_id: ProjectId) -> String;
+    fn get_project(&mut self, project_id: ProjectId) -> Option<Project>;
 }
 
 /// Represents a call to a ledger method. Either a [Query] or a [Update].
@@ -42,7 +47,7 @@ pub enum Call {
 pub enum Query {
     Ping,
     CounterValue,
-    GetProjectUrl { project_id: ProjectId },
+    GetProject { project_id: ProjectId },
 }
 
 /// Reified update to the ledger
@@ -84,9 +89,7 @@ pub fn dispatch(mut ledger: impl Ledger, call: Call) -> Vec<u8> {
         Call::Query(query) => match query {
             Query::Ping => serde_cbor::to_vec(&ledger.ping()),
             Query::CounterValue => serde_cbor::to_vec(&ledger.counter_value()),
-            Query::GetProjectUrl { project_id } => {
-                serde_cbor::to_vec(&ledger.get_project_url(project_id))
-            }
+            Query::GetProject { project_id } => serde_cbor::to_vec(&ledger.get_project(project_id)),
         },
         Call::Update(update) => match update {
             Update::CounterInc => serde_cbor::to_vec(&ledger.counter_inc()),

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -9,7 +9,7 @@ pub mod pwasm;
 pub mod storage;
 
 use interface::dispatch;
-pub use interface::{Call, Ledger, ProjectId, Query, Update};
+pub use interface::{Call, Ledger, Project, ProjectId, Query, Update};
 use storage::Storage;
 
 pub fn call() {
@@ -49,14 +49,11 @@ impl Ledger for Ledger_ {
     }
 
     fn register_project(&mut self, account: ProjectId, url: String) {
-        self.storage.write(&account, &url);
+        self.storage.write(&account, &Project { url });
     }
 
-    fn get_project_url(&mut self, account: ProjectId) -> String {
-        self.storage
-            .read::<String>(&account)
-            .unwrap()
-            .unwrap_or_default()
+    fn get_project(&mut self, account: ProjectId) -> Option<Project> {
+        self.storage.read::<Project>(&account).unwrap()
     }
 }
 
@@ -87,8 +84,8 @@ mod test {
         let account = [0u8; 20];
         let url = "https://example.com";
         ledger.register_project(account, url.into());
-        let expected_url = ledger.get_project_url(account);
-        assert_eq!(url, expected_url);
+        let project = ledger.get_project(account).unwrap();
+        assert_eq!(url, project.url);
     }
 
     fn new_ledger() -> Ledger_ {

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -32,9 +32,10 @@ fn register_project() {
         .register_project(sender, dev_account_address(), url.to_string())
         .wait()
         .unwrap();
-    let url2 = client
-        .get_project_url(dev_account_address())
+    let project = client
+        .get_project(dev_account_address())
         .wait()
+        .unwrap()
         .unwrap();
-    assert_eq!(url, url2);
+    assert_eq!(url, project.url);
 }


### PR DESCRIPTION
We introduce the `Project` struct to the ledger. We replace `Ledger::get_project_url()` with `Ledger::get_project()`.