### PR TITLE
Project registration returns project ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,14 +54,14 @@ To use the client you need the `.oscoin_ledger_address` in your current working
 directory. This file is created by `osc-deploy`.
 
 ~~~rust
-let client = oscoin_client::Client::new_from_file().unwrap();
+let client = Client::new_from_file().unwrap();
 let sender = client.new_account().wait().unwrap();
-let project_address = Address::zero();
 let url = "https://example.com";
-client
-    .register_project(sender, project_address, url.to_string())
+let project_id = client
+    .register_project(sender, url.to_string())
     .wait()
     .unwrap();
+let project = client.get_project(project_id).wait().unwrap().unwrap();
 ~~~
 
 You can find a full example in `examples/project-registration.rs`

--- a/examples/project-registration.rs
+++ b/examples/project-registration.rs
@@ -2,18 +2,17 @@
 //!
 //! This is a copy of a test case in `./tests/end_to_end.rs`.
 use futures::Future;
-use oscoin_client::{Address, Client};
+use oscoin_client::Client;
 
 fn main() {
     let client = Client::new_from_file().unwrap();
 
-    let project_address = Address::zero();
     let sender = client.new_account().wait().unwrap();
     let url = "https://example.com";
-    client
-        .register_project(sender, project_address, url.to_string())
+    let project_id = client
+        .register_project(sender, url.to_string())
         .wait()
         .unwrap();
-    let project = client.get_project(project_address).wait().unwrap().unwrap();
+    let project = client.get_project(project_id).wait().unwrap().unwrap();
     assert_eq!(url, project.url);
 }

--- a/ledger/src/interface.rs
+++ b/ledger/src/interface.rs
@@ -26,7 +26,7 @@ pub trait Ledger {
 
     fn counter_value(&mut self) -> u32;
 
-    fn register_project(&mut self, project_id: ProjectId, url: String);
+    fn register_project(&mut self, url: String) -> ProjectId;
 
     fn get_project(&mut self, project_id: ProjectId) -> Option<Project>;
 }
@@ -58,7 +58,7 @@ pub enum Query {
 #[derive(Serialize, Deserialize, Clone)]
 pub enum Update {
     CounterInc,
-    RegisterProject { project_id: ProjectId, url: String },
+    RegisterProject { url: String },
 }
 
 impl Call {
@@ -95,9 +95,7 @@ pub fn dispatch(mut ledger: impl Ledger, call: Call) -> Vec<u8> {
         },
         Call::Update(update) => match update {
             Update::CounterInc => serde_cbor::to_vec(&ledger.counter_inc()),
-            Update::RegisterProject { project_id, url } => {
-                serde_cbor::to_vec(&ledger.register_project(project_id, url))
-            }
+            Update::RegisterProject { url } => serde_cbor::to_vec(&ledger.register_project(url)),
         },
     };
     res.expect("CBOR serialization never fails")

--- a/ledger/src/pwasm.rs
+++ b/ledger/src/pwasm.rs
@@ -17,6 +17,7 @@ pub trait Env {
     fn write(&mut self, key: &H256, value: &[u8; 32]);
     fn read(&self, key: &H256) -> [u8; 32];
     fn sender(&self) -> Address;
+    fn block_number(&self) -> u64;
 }
 
 /// Implements [Env] for the Parity Wasm Smart Contract environment using the `pwasm_ethereum` crate.
@@ -33,6 +34,10 @@ impl Env for Pwasm {
 
     fn sender(&self) -> Address {
         pwasm_ethereum::sender()
+    }
+
+    fn block_number(&self) -> u64 {
+        pwasm_ethereum::block_number()
     }
 }
 
@@ -56,6 +61,7 @@ mod test_env {
     pub struct TestEnv {
         state: HashMap<H256, [u8; 32]>,
         pub sender: Address,
+        pub block_number: u64,
     }
 
     impl TestEnv {
@@ -78,6 +84,10 @@ mod test_env {
 
         fn sender(&self) -> Address {
             self.sender
+        }
+
+        fn block_number(&self) -> u64 {
+            self.block_number
         }
     }
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -28,15 +28,11 @@ fn register_project() {
     let sender = client.new_account().wait().unwrap();
 
     let url = "https://example.com";
-    client
-        .register_project(sender, dev_account_address(), url.to_string())
+    let project_id = client
+        .register_project(sender, url.to_string())
         .wait()
         .unwrap();
-    let project = client
-        .get_project(dev_account_address())
-        .wait()
-        .unwrap()
-        .unwrap();
+    let project = client.get_project(project_id).wait().unwrap().unwrap();
 
     assert_eq!(url, project.url);
     assert_eq!(project.members, vec![sender.to_fixed_bytes()]);


### PR DESCRIPTION
This change implements #51 and #25.

Before, the user provided the project ID when registering a project. Now the project ID is computed from the transaction data and returned to the user.