### PR TITLE
Explicitly specify patched dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -766,7 +766,7 @@ dependencies = [
  "oscoin_ledger 0.1.0",
  "rustc-hex 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)",
+ "serde_cbor 0.10.1 (git+https://github.com/pyfisch/cbor.git?rev=2c7ed27f0ecf89cdf2883586ad40dde1f216df6e)",
  "web3 0.8.0 (git+https://github.com/tomusdrw/rust-web3.git?rev=db4443ee16765c0754a87d9359d8f6b9e0c04d3a)",
 ]
 
@@ -789,7 +789,7 @@ dependencies = [
  "pwasm-ethereum 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pwasm-std 0.13.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)",
- "serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)",
+ "serde_cbor 0.10.1 (git+https://github.com/pyfisch/cbor.git?rev=2c7ed27f0ecf89cdf2883586ad40dde1f216df6e)",
 ]
 
 [[package]]
@@ -1280,8 +1280,8 @@ dependencies = [
 
 [[package]]
 name = "serde_cbor"
-version = "0.10.0"
-source = "git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std#6f7020ac083820bfa64d52e063e676b0eab715a4"
+version = "0.10.1"
+source = "git+https://github.com/pyfisch/cbor.git?rev=2c7ed27f0ecf89cdf2883586ad40dde1f216df6e#2c7ed27f0ecf89cdf2883586ad40dde1f216df6e"
 dependencies = [
  "byteorder 1.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "half 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2035,7 +2035,7 @@ dependencies = [
 "checksum semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1d7eb9ef2c18661902cc47e535f9bc51b78acd254da71d375c2f6720d9a40403"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum serde 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "fec2851eb56d010dc9a21b89ca53ee75e6528bab60c11e89d38390904982da9f"
-"checksum serde_cbor 0.10.0 (git+https://github.com/geigerzaehler/cbor.git?branch=to-vec-no-std)" = "<none>"
+"checksum serde_cbor 0.10.1 (git+https://github.com/pyfisch/cbor.git?rev=2c7ed27f0ecf89cdf2883586ad40dde1f216df6e)" = "<none>"
 "checksum serde_derive 1.0.99 (registry+https://github.com/rust-lang/crates.io-index)" = "cb4dc18c61206b08dc98216c98faa0232f4337e1e1b8574551d5bad29ea1b425"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
 "checksum sha1 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2579985fda508104f7587689507983eadd6a6e84dd35d6d115361f530916fa0d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,21 +15,14 @@ clap = "2.31"
 env_logger = "0.6.2"
 futures = "0.1.28"
 hex = "0.3.1"
-web3 = "0.8.0"
-
-[dev-dependencies]
-pwasm-utils-cli = "0.10.0"
-
-
-[patch.crates-io]
 # We require the patches https://github.com/tomusdrw/rust-web3/pull/242
 # and https://github.com/tomusdrw/rust-web3/pull/250
 # Once a new version of web3 is released we can update it.
 web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "db4443ee16765c0754a87d9359d8f6b9e0c04d3a" }
+
+[dev-dependencies]
 # See https://github.com/paritytech/wasm-utils/pull/132
 pwasm-utils-cli = { git = "https://github.com/oscoin/wasm-utils.git", branch = "pack-min-pages" }
-# See https://github.com/oscoin/oscoin-parity-wasm-prototype/pull/45
-serde_cbor = { git = "https://github.com/geigerzaehler/cbor.git", branch = "to-vec-no-std" }
 
 [workspace]
 members = ["deploy", "ledger", "ledger-spec", "ledger/pwasm"]

--- a/client/Cargo.toml
+++ b/client/Cargo.toml
@@ -13,5 +13,9 @@ ethereum-types = "^0.6.0"
 futures = "0.1.28"
 rustc-hex = "2.0.1"
 serde = "1.0"
-serde_cbor = "=0.10.0"
-web3 = "0.8.0"
+# See https://github.com/oscoin/oscoin-parity-wasm-prototype/pull/45
+serde_cbor = { git = "https://github.com/pyfisch/cbor.git", rev = "2c7ed27f0ecf89cdf2883586ad40dde1f216df6e" }
+# We require the patches https://github.com/tomusdrw/rust-web3/pull/242
+# and https://github.com/tomusdrw/rust-web3/pull/250
+# Once a new version of web3 is released we can update it.
+web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "db4443ee16765c0754a87d9359d8f6b9e0c04d3a" }

--- a/deploy/Cargo.toml
+++ b/deploy/Cargo.toml
@@ -6,7 +6,10 @@ authors = ["Thomas Scholtes <thomas@monadic.xyz>"]
 edition = "2018"
 
 [dependencies]
-web3 = "0.8.0"
 env_logger = "0.6.2"
 hex = "0.3.1"
 clap = "2.31"
+# We require the patches https://github.com/tomusdrw/rust-web3/pull/242
+# and https://github.com/tomusdrw/rust-web3/pull/250
+# Once a new version of web3 is released we can update it.
+web3 = { git = "https://github.com/tomusdrw/rust-web3.git", rev = "db4443ee16765c0754a87d9359d8f6b9e0c04d3a" }

--- a/ledger/Cargo.toml
+++ b/ledger/Cargo.toml
@@ -13,7 +13,13 @@ pwasm-ethereum = "0.8"
 pwasm-abi = "0.2"
 lazy_static = { version = "1.3.0", features = ["spin_no_std"] }
 serde = { version = "1.0", default-features = false, features = ["derive", "alloc"] }
-serde_cbor = { version = "=0.10.0", default-features = false, features = ["alloc"] }
+
+[dependencies.serde_cbor]
+# See https://github.com/oscoin/oscoin-parity-wasm-prototype/pull/45
+git = "https://github.com/pyfisch/cbor.git"
+rev = "2c7ed27f0ecf89cdf2883586ad40dde1f216df6e"
+default-features = false
+features = ["alloc"]
 
 [features]
 default = ["std"]


### PR DESCRIPTION
To make `oscoin_client` usable as a library outside of this workspace we explicitly list the patches in the packages’ `Cargo.toml` instead of only declaring them in the top-level `patch` section.