### PR TITLE
Extend project with additonal fields

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -160,15 +160,24 @@ impl Client {
     pub fn register_project<'a>(
         &'a self,
         sender: Address,
-        url: String,
+        name: String,
+        description: String,
+        img_url: String,
     ) -> impl Future<Item = ProjectId, Error = Error> + 'a {
-        self.submit(sender, LedgerUpdate::RegisterProject { url })
-            .map(move |receipt| {
-                let block = receipt
-                    .block_number
-                    .expect("Receipt must have block number");
-                compute_project_id(sender.as_fixed_bytes().into(), block.as_u64())
-            })
+        self.submit(
+            sender,
+            LedgerUpdate::RegisterProject {
+                name,
+                description,
+                img_url,
+            },
+        )
+        .map(move |receipt| {
+            let block = receipt
+                .block_number
+                .expect("Receipt must have block number");
+            compute_project_id(sender.as_fixed_bytes().into(), block.as_u64())
+        })
     }
 
     pub fn get_project(

--- a/dev-node/run
+++ b/dev-node/run
@@ -5,6 +5,7 @@ set -euo pipefail
 cd $(dirname $BASH_SOURCE[0])
 
 parity \
+	--logging trace \
   --config ./config.toml \
   account import ./dev-key.json
 parity --config ./config.toml

--- a/dev-node/run
+++ b/dev-node/run
@@ -5,7 +5,6 @@ set -euo pipefail
 cd $(dirname $BASH_SOURCE[0])
 
 parity \
-	--logging trace \
   --config ./config.toml \
   account import ./dev-key.json
 parity --config ./config.toml

--- a/examples/project-registration.rs
+++ b/examples/project-registration.rs
@@ -8,11 +8,21 @@ fn main() {
     let client = Client::new_from_file().unwrap();
 
     let sender = client.new_account().wait().unwrap();
-    let url = "https://example.com";
+    let name = "monokol";
+    let description = "Looking glass into the future.";
+    let img_url = "https://monok.el/img/logo.svg";
     let project_id = client
-        .register_project(sender, url.to_string())
+        .register_project(
+            sender,
+            name.to_owned(),
+            description.to_owned(),
+            img_url.to_owned(),
+        )
         .wait()
         .unwrap();
     let project = client.get_project(project_id).wait().unwrap().unwrap();
-    assert_eq!(url, project.url);
+    assert_eq!(project.name, name);
+    assert_eq!(project.description, description);
+    assert_eq!(project.img_url, img_url);
+    assert_eq!(project.members, vec![sender.to_fixed_bytes()]);
 }

--- a/ledger/src/interface.rs
+++ b/ledger/src/interface.rs
@@ -14,7 +14,9 @@ pub type AccountId = [u8; 20];
 
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Project {
-    pub url: String,
+    pub description: String,
+    pub name: String,
+    pub img_url: String,
     pub members: Vec<AccountId>,
 }
 
@@ -26,7 +28,8 @@ pub trait Ledger {
 
     fn counter_value(&mut self) -> u32;
 
-    fn register_project(&mut self, url: String) -> ProjectId;
+    fn register_project(&mut self, name: String, description: String, img_url: String)
+        -> ProjectId;
 
     fn get_project(&mut self, project_id: ProjectId) -> Option<Project>;
 }
@@ -58,7 +61,11 @@ pub enum Query {
 #[derive(Serialize, Deserialize, Clone)]
 pub enum Update {
     CounterInc,
-    RegisterProject { url: String },
+    RegisterProject {
+        name: String,
+        description: String,
+        img_url: String,
+    },
 }
 
 impl Call {
@@ -95,7 +102,11 @@ pub fn dispatch(mut ledger: impl Ledger, call: Call) -> Vec<u8> {
         },
         Call::Update(update) => match update {
             Update::CounterInc => serde_cbor::to_vec(&ledger.counter_inc()),
-            Update::RegisterProject { url } => serde_cbor::to_vec(&ledger.register_project(url)),
+            Update::RegisterProject {
+                name,
+                description,
+                img_url,
+            } => serde_cbor::to_vec(&ledger.register_project(name, description, img_url)),
         },
     };
     res.expect("CBOR serialization never fails")

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -59,10 +59,23 @@ impl Ledger for Ledger_ {
         self.storage().read(COUNTER_KEY).unwrap().unwrap_or(0)
     }
 
-    fn register_project(&mut self, url: String) -> ProjectId {
+    fn register_project(
+        &mut self,
+        name: String,
+        description: String,
+        img_url: String,
+    ) -> ProjectId {
         let members = vec![self.env.sender().to_fixed_bytes()];
         let id = compute_project_id(self.env.sender(), self.env.block_number());
-        self.storage().write(&id, &Project { url, members });
+        self.storage().write(
+            &id,
+            &Project {
+                name,
+                description,
+                img_url,
+                members,
+            },
+        );
         id
     }
 
@@ -112,10 +125,16 @@ mod test {
     #[test]
     fn register_project() {
         let mut ledger = new_ledger();
-        let url = "https://example.com";
-        let project_id = ledger.register_project(url.into());
+
+        let name = "monokol";
+        let description = "Looking glass into the future.";
+        let img_url = "https://monok.el/img/logo.svg";
+        let project_id = ledger.register_project(name.into(), description.into(), img_url.into());
         let project = ledger.get_project(project_id).unwrap();
-        assert_eq!(project.url, url);
+
+        assert_eq!(project.name, name);
+        assert_eq!(project.description, description);
+        assert_eq!(project.img_url, img_url);
         assert_eq!(project.members, vec![test_sender().to_fixed_bytes()]);
     }
 

--- a/ledger/src/lib.rs
+++ b/ledger/src/lib.rs
@@ -129,7 +129,8 @@ mod test {
         let name = "monokol";
         let description = "Looking glass into the future.";
         let img_url = "https://monok.el/img/logo.svg";
-        let project_id = ledger.register_project(name.into(), description.into(), img_url.into());
+        let project_id =
+            ledger.register_project(name.to_owned(), description.to_owned(), img_url.to_owned());
         let project = ledger.get_project(project_id).unwrap();
 
         assert_eq!(project.name, name);

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -33,9 +33,9 @@ fn register_project() {
     let project_id = client
         .register_project(
             sender,
-            name.to_string(),
-            description.to_string(),
-            img_url.to_string(),
+            name.to_owned(),
+            description.to_owned(),
+            img_url.to_owned(),
         )
         .wait()
         .unwrap();

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -58,12 +58,12 @@ fn list_projects() {
 
     let sender = client.new_account().wait().unwrap();
 
-    let img_url_vec: Vec<String> = (0..9)
+    let img_url_vec: Vec<String> = (0..7)
         .map(|ix| "https://img.examples.com/".to_owned() + &ix.to_string())
         .collect();
     let img_url_set: BTreeSet<String> = img_url_vec.iter().cloned().collect();
 
-    for url in img_url_vec.iter().take(9) {
+    for url in img_url_vec.iter().take(7) {
         client
             .register_project(
                 sender,

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -27,13 +27,23 @@ fn register_project() {
 
     let sender = client.new_account().wait().unwrap();
 
-    let url = "https://example.com";
+    let name = "monokol";
+    let description = "Looking glass into the future.";
+    let img_url = "https://monok.el/img/logo.svg";
     let project_id = client
-        .register_project(sender, url.to_string())
+        .register_project(
+            sender,
+            name.to_string(),
+            description.to_string(),
+            img_url.to_string(),
+        )
         .wait()
         .unwrap();
+
     let project = client.get_project(project_id).wait().unwrap().unwrap();
 
-    assert_eq!(url, project.url);
+    assert_eq!(project.name, name);
+    assert_eq!(project.description, description);
+    assert_eq!(project.img_url, img_url);
     assert_eq!(project.members, vec![sender.to_fixed_bytes()]);
 }

--- a/tests/end_to_end.rs
+++ b/tests/end_to_end.rs
@@ -58,14 +58,19 @@ fn list_projects() {
 
     let sender = client.new_account().wait().unwrap();
 
-    let url_vec: Vec<String> = (0..9)
-        .map(|ix| "https://examples".to_string() + &ix.to_string() + ".com")
+    let img_url_vec: Vec<String> = (0..9)
+        .map(|ix| "https://img.examples.com/".to_owned() + &ix.to_string())
         .collect();
-    let url_set: BTreeSet<String> = url_vec.iter().cloned().collect();
+    let img_url_set: BTreeSet<String> = img_url_vec.iter().cloned().collect();
 
-    for url in url_vec.iter().take(9) {
+    for url in img_url_vec.iter().take(9) {
         client
-            .register_project(sender, url.to_string())
+            .register_project(
+                sender,
+                "name".to_owned(),
+                "description".to_owned(),
+                url.to_owned(),
+            )
             .wait()
             .unwrap();
     }
@@ -76,11 +81,11 @@ fn list_projects() {
     // in the start.
     // Sets are used for ease of comparison and to remove duplicates.
     assert_eq!(
-        url_set,
+        img_url_set,
         project_list
             .clone()
             .iter()
-            .map(|project| { project.url.clone() })
+            .map(|project| { project.img_url.clone() })
             .collect()
     );
 


### PR DESCRIPTION
To complete the end-to-end integration with the product MVP we need more fields to be stored. Those are metadata fields provided by the user creating the project. For now this is an extension of the Project entity itself until we look more closely into proper metadata storage. It's understood as metadata as there are no guarantees on uniqueness and are complete free-form inputs by the user.

Field changes:
(+) name
(+) description
(=) url -> img_url

* update ledger project registration
* update client project refgistration
* update tests